### PR TITLE
fix(deps): Pin commonmarker to newer ver w/o vuln

### DIFF
--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'graphql', '~> 2.0'
 
   # rendering
-  spec.add_dependency 'commonmarker', '~> 0.16'
+  spec.add_dependency 'commonmarker', '~> 0.23'
   spec.add_dependency 'escape_utils', '~> 1.2.2'
   spec.add_dependency 'extended-markdown-filter', '~> 0.4'
   spec.add_dependency 'gemoji', '~> 3.0'


### PR DESCRIPTION
Addresses these dependabot alerts:

- https://github.com/brettchalupa/graphql-docs/security/dependabot/1
- https://github.com/brettchalupa/graphql-docs/security/dependabot/2
