### PR TITLE
Pin commonmarker to newer ver w/ security fixes & drop Ruby 2.5 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.1.2, 3.0.4, 2.7.6, 2.6.10, 2.5.9]
+        ruby-version: [3.1.2, 3.0.4, 2.7.6, 2.6.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 A concise overview of the public-facing changes to the gem from version to version. Does not include internal changes to the dev experience for the gem.
 
+## Unreleased
+
+The follow changes will be coming in the upcoming v4.0.0 release.
+
+- **Breaking change**: drop support for Ruby 2.5 and earlier
+- Fixes
+  - Upgrade commonmarker to latest ver to address security vulnerabilities
+
 ## v3.0.1
 
 - fix: Relieves `EscapeUtils.escape_html is deprecated. Use GCI.escapeHTML instead, it's faster` deprecation warning until it gets released in an downstream dependency

--- a/README.md
+++ b/README.md
@@ -181,6 +181,21 @@ The format of `schema_member_path` is a dot delimited path to the schema member.
 "Mutation.addLike" # a mutation
 ```
 
+## Supported Ruby Versions
+
+The gem currently supports **Ruby 2.6 and newer**. Any dropping of Ruby version
+support is considered a breaking change and means a major release for the gem.
+
+## Upgrading
+
+This project aims to strictly follow [Semantic Versioning](https://semver.org/).
+Minor and patch level updates can be done with pretty high confidence that your usage won't break.
+
+Review the
+[Changelog](https://github.com/brettchalupa/graphql-docs/blob/main/CHANGELOG.md)
+for detailed changes for each release. The intent is to make upgrading as
+painless as possible.
+
 ## Development
 
 After checking out the repo, run `script/bootstrap` to install dependencies. Then, run `rake test` to run the tests. You can also run `bundle exec rake console` for an interactive prompt that will allow you to experiment.

--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'graphql', '~> 2.0'
 
   # rendering
-  spec.add_dependency 'commonmarker', '~> 0.16'
+  spec.add_dependency 'commonmarker', '~> 0.23'
   spec.add_dependency 'escape_utils', '~> 1.2.2'
   spec.add_dependency 'extended-markdown-filter', '~> 0.4'
   spec.add_dependency 'gemoji', '~> 3.0'

--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.6.0'
+
   spec.add_dependency 'graphql', '~> 2.0'
 
   # rendering


### PR DESCRIPTION
To get the latest ver of commonmarker, which has security vuln fixes,
this project needs to drop support for older Ruby versions. As of this
commit, the stable release series of Ruby are:

- 3.1
- 3.0
- 2.7

Ruby 2.6 is EOL but it seems to be working still, so this continues to
maintain support for it.

Addresses these dependabot alerts:

- https://github.com/brettchalupa/graphql-docs/security/dependabot/1
- https://github.com/brettchalupa/graphql-docs/security/dependabot/2