### PR TITLE
chore: require latest ver of html-pipeline to address dep warning

### DIFF
--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -39,10 +39,10 @@ Gem::Specification.new do |spec|
 
   # rendering
   spec.add_dependency 'commonmarker', '~> 0.23'
-  spec.add_dependency 'escape_utils', '~> 1.2.2'
+  spec.add_dependency 'escape_utils', '~> 1.2'
   spec.add_dependency 'extended-markdown-filter', '~> 0.4'
   spec.add_dependency 'gemoji', '~> 3.0'
-  spec.add_dependency 'html-pipeline', '~> 2.9'
+  spec.add_dependency 'html-pipeline', '>= 2.14.3', '~> 2.14'
   spec.add_dependency 'sass', '~> 3.4'
 
   spec.add_development_dependency 'awesome_print'


### PR DESCRIPTION
```
EscapeUtils.escape_html is deprecated. Use GCI.escapeHTML instead, it's faster
```

v2.14.3 has a fix to address that warning, so we want that as the
minimum version so people don't see that when generating their docs. See
https://github.com/gjtorikian/html-pipeline/pull/365 for reference.

Remove stricter pinning of `escape_utils` since we can use newer
version.
