### PR TITLE
chore: be stricter about min commonmarker ver

### DIFF
--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'graphql', '~> 2.0'
 
   # rendering
-  spec.add_dependency 'commonmarker', '~> 0.23'
+  spec.add_dependency 'commonmarker', '>= 0.23.6', '~> 0.23'
   spec.add_dependency 'escape_utils', '~> 1.2'
   spec.add_dependency 'extended-markdown-filter', '~> 0.4'
   spec.add_dependency 'gemoji', '~> 3.0'


### PR DESCRIPTION
So the gemspec isn't satisfied by still vuln vers, see https://github.com/brettchalupa/graphql-docs/security/dependabot/1
