### PR TITLE
feat: replace Ruby sass with dartsass

### DIFF
--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'extended-markdown-filter', '~> 0.4'
   spec.add_dependency 'gemoji', '~> 3.0'
   spec.add_dependency 'html-pipeline', '>= 2.14.3', '~> 2.14'
-  spec.add_dependency 'sass', '~> 3.4'
+  spec.add_dependency 'dartsass', '~> 1.49'
 
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'html-proofer', '~> 3.4'

--- a/lib/graphql-docs/generator.rb
+++ b/lib/graphql-docs/generator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'erb'
-require 'sass'
 
 module GraphQLDocs
   class Generator
@@ -85,7 +84,7 @@ module GraphQLDocs
         FileUtils.mkdir_p(File.join(@options[:output_dir], 'assets'))
 
         sass = File.join(assets_dir, 'css', 'screen.scss')
-        system `sass --sourcemap=none #{sass}:#{@options[:output_dir]}/assets/style.css`
+        system `bundle exec dartsass --no-source-map=none #{sass} #{@options[:output_dir]}/assets/style.css`
 
         FileUtils.cp_r(File.join(assets_dir, 'images'), File.join(@options[:output_dir], 'assets'))
         FileUtils.cp_r(File.join(assets_dir, 'webfonts'), File.join(@options[:output_dir], 'assets'))


### PR DESCRIPTION
The Ruby sass gem has been deprecated and is no longer actively maintained.
This replaces it with the dartsass gem, which uses a compiled ver of the
canonical sass compiler. It allows for `bundle exec dartsass` compile
styles. It has slightly different CLI options.

I'm truthfully on the fence about whether or not this project even needs
Sass, but it's easier to drop this in and maintain the existing
styles than to combine them all and deal with a 1k+ line stylesheet.

Fixes https://github.com/brettchalupa/graphql-docs/issues/86

BREAKING CHANGE: removes sass gem; if you rely on it, bundle it directly or call out to dartsass

---

This will be part of the upcoming 4.0.0 release.
