### PR TITLE
Introduce CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GraphQLDocs
 
-Easily generate beautiful documentation from your GraphQL schema.
+Ruby library and CLI for easily generating beautiful documentation from your GraphQL schema.
 
 ![sample](https://cloud.githubusercontent.com/assets/64050/23438604/6a23add0-fdc7-11e6-8852-ef41e8451033.png)
 
@@ -20,6 +20,8 @@ gem install graphql-docs
 
 ## Usage
 
+GraphQLDocs can be used as a Ruby library to build the documentation website. Using it as a Ruby library allows for more control and using every supported option. Here's an example:
+
 ``` ruby
 # pass in a filename
 GraphQLDocs.build(filename: filename)
@@ -32,6 +34,20 @@ schema = GraphQL::Schema.define do
   query query_type
 end
 GraphQLDocs.build(schema: schema)
+```
+
+GrophQLDocs also has a simplified CLI (`graphql-docs`) that gets installed with the gem:
+
+``` console
+graphql-docs schema.graphql
+```
+
+That will generate the output in the `output` dir.
+
+See all of the supported CLI options with:
+
+``` console
+graphql-docs -h
 ```
 
 ## Breakdown

--- a/exe/graphql-docs
+++ b/exe/graphql-docs
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+
+require "graphql-docs"
+require "optparse"
+
+NAME = "graphql-docs".freeze
+
+opts = {}
+OptionParser.new do |parser|
+  parser.program_name = NAME
+  parser.banner = <<~EOS
+
+  Generate GraphQL docs from the passed in schema file.
+
+  Usage: graphql-docs SCHEMA
+
+  The only required argument is the path to the schema file to generate the site from.
+
+  Examples:
+    $ graphql-docs schema.graphql
+    $ graphql-docs schema.graphql -o _docs
+
+  Options:
+  EOS
+
+  parser.version = GraphQLDocs::VERSION
+
+  parser.on("-o", "--output-dir DIR", "Where the site is generated to, defaults to ./output")
+  parser.on("-d", "--delete-output", "Delete the output-dir before generating, defaults to false")
+  parser.on("-b", "--base-url URL", "URL to preprend for assets and links, defaults to \"\"")
+  parser.on("--verbose", "Run in verbose mode")
+end.parse!(into: opts)
+
+def err(msg)
+  abort("#{NAME}: Error: #{msg}")
+end
+
+schema = ARGV[0]
+if schema.nil?
+  err("schema must be specified")
+end
+opts[:filename] = schema
+
+verbose = opts.delete(:verbose)
+
+puts("Generating site with the following options: #{opts}") if verbose
+
+opts.transform_keys! { |k| k.to_s.gsub("-", "_").to_sym }
+GraphQLDocs.build(opts)
+
+puts("Site successfully generated in: #{opts[:output_dir] || 'output' }") if verbose

--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Easily generate beautiful documentation from your GraphQL schema.'
   spec.description   = <<-EOF
-    GraphQLDocs is a library for generating HTML from a GraphQL API's schema
+    Library and CLI for generating a website from a GraphQL API's schema
     definition. With ERB templating support and a plethora of configuration
     options, you can customize the output to your needs. The library easily
     integrates with your Ruby deployment toolchain to ensure the docs for your

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CliTest < Minitest::Test
+  def setup
+    @schema = File.join(fixtures_dir, 'sw-schema.graphql')
+  end
+
+  def test_cli_works
+    FileUtils.rm_rf("output")
+    assert cmd("#{@schema}")
+    assert File.exist?(File.join("output", 'index.html'))
+  end
+
+  def test_cli_works_with_output_dir
+    clean_up_output # NOTE: this is the fixture output dir
+    schema = File.join(fixtures_dir, 'sw-schema.graphql')
+    assert cmd("#{@schema} -o #{output_dir}")
+    assert File.exist?(File.join(output_dir, 'index.html'))
+  end
+
+  def test_cli_requires_schema
+    _out, err = capture_subprocess_io do
+      refute cmd("", exception: false)
+    end
+    assert_match /schema must be specified/, err
+  end
+
+  def test_cli_help
+    out, err = capture_subprocess_io do
+      assert cmd("--help")
+    end
+    assert_match /Usage/, out
+    assert err.empty?
+  end
+
+  def test_cli_verbose
+    out, err = capture_subprocess_io do
+      assert cmd("#{@schema} --verbose")
+    end
+    assert_match /Generating site/, out
+    assert_match /Site successfully generated/, out
+    assert err.empty?
+  end
+
+  def test_cli_base_url
+    out, err = capture_subprocess_io do
+      assert cmd("#{@schema} -b https://example.com")
+    end
+    assert err.empty?
+    assert File.read(File.join("output", 'index.html')).include?("<link rel=\"stylesheet\" href=\"https://example.com/assets/style.css\">")
+  end
+
+  private
+
+  def cmd(args, exception: true)
+    system("ruby -Ilib ./exe/graphql-docs #{args}", exception: exception)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,13 @@ def fixtures_dir
   File.join(File.dirname(__FILE__), 'graphql-docs', 'fixtures')
 end
 
-FileUtils.rm_rf(File.join(fixtures_dir, 'output'))
+def output_dir
+  File.join(fixtures_dir, 'output')
+end
+def clean_up_output
+  FileUtils.rm_rf(output_dir)
+end
+clean_up_output
 
 class QueryType < GraphQL::Schema::Object
   field :test, Int, "Title paragraph.


### PR DESCRIPTION
This allows those with the gem installed to use the `graphql-docs`
command, which (for now) has a simplified interface for generating the
site without needing to write any Ruby code.

A few notes:

- I'm certainly open to supporting as many options as possible, but
  those would be great contributions from others who want to see them
- Uses `OptionParser` because I like it and it's in the standard library
- Has some naive option key transforming, which works for now but may
  not be good enough for the long term

Finishes https://github.com/brettchalupa/graphql-docs/issues/2

## Help Output

Here's what running `graphql-docs --help` outputs:

``` console
Generate GraphQL docs from the passed in schema file.

Usage: graphql-docs SCHEMA

The only required argument is the path to the schema file to generate the site from.

Examples:
  $ graphql-docs schema.graphql
  $ graphql-docs schema.graphql -o _docs

Options:
    -o, --output-dir DIR             Where the site is generated to, defaults to ./output
    -d, --delete-output              Delete the output-dir before generating, defaults to false
    -b, --base-url URL               URL to preprend for assets and links, defaults to ""
        --verbose                    Run in verbose mode
```
