### PR TITLE
feat(parser): add deprecation information for field arguments

### DIFF
--- a/lib/graphql-docs/parser.rb
+++ b/lib/graphql-docs/parser.rb
@@ -177,6 +177,10 @@ module GraphQLDocs
             h[:description] = arg.description
             h[:type] = generate_type(arg.type)
             h[:default_value] = arg.default_value if arg.default_value?
+            if arg.respond_to?(:deprecation_reason) && arg.deprecation_reason
+              h[:is_deprecated] = true
+              h[:deprecation_reason] = arg.deprecation_reason
+            end
             hash[:arguments] << h
           end
         end

--- a/test/graphql-docs/parser_test.rb
+++ b/test/graphql-docs/parser_test.rb
@@ -14,7 +14,7 @@ class ParserTest < Minitest::Test
     schema = MySchema
 
     results = GraphQLDocs::Parser.new(schema, {}).parse
-    assert_equal 'test', results[:operation_types][0][:fields][0][:name]
+    assert_equal 'myField', results[:operation_types][0][:fields][0][:name]
     assert_equal "Title paragraph.\n  ```\n    line1\n    line2\n        line3\n  ```", results[:operation_types][0][:fields][0][:description]
   end
 
@@ -112,5 +112,15 @@ class ParserTest < Minitest::Test
     assert results[:object_types]
     user = results[:object_types].first
     assert_equal 'The id of the user', user[:fields].first[:description]
+  end
+
+  def test_deprecations
+    schema = MySchema
+
+    fields = GraphQLDocs::Parser.new(schema, {}).parse[:operation_types][0][:fields]
+
+    refute fields[0][:is_deprecated]
+    assert fields[1][:is_deprecated]
+    assert fields[2][:arguments][0][:is_deprecated]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,12 +20,18 @@ end
 clean_up_output
 
 class QueryType < GraphQL::Schema::Object
-  field :test, Int, "Title paragraph.
+  field :my_field, Int, "Title paragraph.
   ```
     line1
     line2
         line3
   ```", null: false
+
+  field :deprecated_field, Int, deprecation_reason: "Not useful any more"
+
+  field :field_with_deprecated_arg, Int do
+    argument :my_arg, Int, required: false, deprecation_reason: "Not useful any more"
+  end
 end
 
 class MySchema < GraphQL::Schema


### PR DESCRIPTION
Just like fields have deprecation information, add deprecation information for field arguments as well.

This is useful information that has been missing so far from the parser. It can be used by custom templates that display deprecated arguments differently, such as showing a warning or hiding the deprecated argument altogether.

The implementation follows the same logic as `field` a few lines above.