### PR TITLE
Drop Ruby 2.6 on CI & add Ruby 3.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.1.2, 3.0.4, 2.7.6]
+        ruby-version: [3.2, 3.1, 3.0, 2.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.1.2, 3.0.4, 2.7.6, 2.6.10]
+        ruby-version: [3.1.2, 3.0.4, 2.7.6]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -197,8 +197,11 @@ The format of `schema_member_path` is a dot delimited path to the schema member.
 
 ## Supported Ruby Versions
 
-The gem currently supports **Ruby 2.6 and newer**. Any dropping of Ruby version
-support is considered a breaking change and means a major release for the gem.
+The gem officially supports **Ruby 2.7 and newer**.
+
+A note about Ruby 2.6: It works, but it requires activesupport to be set to a version less than 7 due to it dropping Ruby 2.6 support. Ruby 2.6 is no longer tested on CI.
+
+Any dropping of Ruby version support is considered a breaking change and means a major release for the gem.
 
 ## Upgrading
 


### PR DESCRIPTION
Ruby 2.6 is EOL and upstream dependencies require a more modern Ruby. I don't want to pin activesupport to be < 7 or something like that, so I think this works for now by not explicitly testing it on CI but calling out that the gem should work without issue.

This also adds Ruby 3.2 to the testing matrix.

Fixes https://github.com/brettchalupa/graphql-docs/issues/137