### PR TITLE
Fix test suite & allow CLI to work outside of Bundler projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ A concise overview of the public-facing changes to the gem from version to versi
 
 ## Unreleased
 
-- CLI version flag: `graphql-docs --version` / `graphql-docs -v`
+- feat: CLI version flag: `graphql-docs --version` / `graphql-docs -v`
+- fix: CLI now works outside of a Bundler project
+- fix: test suite
 
 ## v4.0.0 - 2023-01-26
 
@@ -14,7 +16,7 @@ A concise overview of the public-facing changes to the gem from version to versi
 - Fixes:
   - Upgrade commonmarker to latest ver to address security vulnerabilities
   - commonmarker pinned to version without security vulnerability
-- Chores
+- Chores:
   - Dev env refresh
 
 ## v3.0.1 - 2022-10-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ A concise overview of the public-facing changes to the gem from version to versi
 
 ## Unreleased
 
+- CLI version flag: `graphql-docs --version` / `graphql-docs -v`
+
 ## v4.0.0 - 2023-01-26
 
 - **Breaking change**: drop support for Ruby 2.5 and earlier

--- a/lib/graphql-docs/generator.rb
+++ b/lib/graphql-docs/generator.rb
@@ -85,7 +85,7 @@ module GraphQLDocs
         FileUtils.mkdir_p(File.join(@options[:output_dir], 'assets'))
 
         sass = File.join(assets_dir, 'css', 'screen.scss')
-        system `bundle exec dartsass --no-source-map=none #{sass} #{@options[:output_dir]}/assets/style.css`
+        system `dartsass --no-source-map=none #{sass} #{@options[:output_dir]}/assets/style.css`
 
         FileUtils.cp_r(File.join(assets_dir, 'images'), File.join(@options[:output_dir], 'assets'))
         FileUtils.cp_r(File.join(assets_dir, 'webfonts'), File.join(@options[:output_dir], 'assets'))

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -52,6 +52,14 @@ class CliTest < Minitest::Test
     assert File.read(File.join("output", 'index.html')).include?("<link rel=\"stylesheet\" href=\"https://example.com/assets/style.css\">")
   end
 
+  def test_cli_version
+    out, err = capture_subprocess_io do
+      assert cmd("--version")
+    end
+    assert_match /#{GraphQLDocs::VERSION}/, out
+    assert err.empty?
+  end
+
   private
 
   def cmd(args, exception: true)

--- a/test/graphql-docs/parser_test.rb
+++ b/test/graphql-docs/parser_test.rb
@@ -46,7 +46,7 @@ class ParserTest < Minitest::Test
 
   def test_directives
     names = @gh_results[:directive_types].map { |t| t[:name] }
-    assert_equal %w[deprecated include oneOf preview skip], names
+    assert_equal %w[deprecated include oneOf preview skip specifiedBy], names
 
     preview_directive = @gh_results[:directive_types].find { |t| t[:name] == 'deprecated' }
     assert_equal %i[FIELD_DEFINITION ENUM_VALUE ARGUMENT_DEFINITION INPUT_FIELD_DEFINITION], preview_directive[:locations]


### PR DESCRIPTION
summary of changes:

- fix(tests): new directive type in GH schema
- chore: add version flag to CHANGELOG & integration test
- fix(cli): remove `bundle exec` from dartsass run
- chore: update CHANGELOG

fixes https://github.com/brettchalupa/graphql-docs/issues/144
fixes https://github.com/brettchalupa/graphql-docs/issues/143
