### PR TITLE
Update to latest sass with sass-embedded gem

### DIFF
--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'extended-markdown-filter', '~> 0.4'
   spec.add_dependency 'gemoji', '~> 3.0'
   spec.add_dependency 'html-pipeline', '>= 2.14.3', '~> 2.14'
-  spec.add_dependency 'dartsass', '~> 1.49'
+  spec.add_dependency 'sass-embedded', '~> 1.58'
 
   spec.add_development_dependency 'html-proofer', '~> 3.4'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/lib/graphql-docs/generator.rb
+++ b/lib/graphql-docs/generator.rb
@@ -2,6 +2,7 @@
 
 require 'erb'
 require 'fileutils'
+require 'sass-embedded'
 
 module GraphQLDocs
   class Generator
@@ -84,8 +85,8 @@ module GraphQLDocs
         assets_dir = File.join(File.dirname(__FILE__), 'layouts', 'assets')
         FileUtils.mkdir_p(File.join(@options[:output_dir], 'assets'))
 
-        sass = File.join(assets_dir, 'css', 'screen.scss')
-        system `dartsass --no-source-map=none #{sass} #{@options[:output_dir]}/assets/style.css`
+        css = Sass.compile(File.join(assets_dir, 'css', 'screen.scss')).css
+        File.write(File.join(@options[:output_dir], 'assets', 'style.css'), css)
 
         FileUtils.cp_r(File.join(assets_dir, 'images'), File.join(@options[:output_dir], 'assets'))
         FileUtils.cp_r(File.join(assets_dir, 'webfonts'), File.join(@options[:output_dir], 'assets'))


### PR DESCRIPTION
The dartsass gem has never been updated since its very first release. This PR updates to latest version of dart sass using sass-embedded gem, which has version and feature matching release with dart-sass.