### PR TITLE
Drop EOL rubies 2.6, 2.7, 3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Ruby
 
-on: [push,pull_request]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -8,14 +8,14 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.2, 3.1, 3.0, 2.7]
+        ruby-version: [3.3, 3.2, 3.1]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
-    - name: Run the test suite
-      run: bundle exec rake
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Run the test suite
+        run: bundle exec rake

--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_dependency 'graphql', '~> 2.0'
 


### PR DESCRIPTION
BREAKING CHANGE: those ruby versions are no longer maintained

This will be included in the v5.0.0 release

Fixes https://github.com/brettchalupa/graphql-docs/issues/139