### PR TITLE
2 Space Indents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ Style/StringLiterals:
 
 Naming/FileName:
   Enabled: false
+
+Layout/IndentationWidth:
+  Width: 2


### PR DESCRIPTION
Added 2 space idents to .rubocop.yml to be consistent with the code files having 2 spaces indents.