### PR TITLE
add logger and ostruct to gemspec

### DIFF
--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -44,6 +44,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gemoji', '~> 3.0'
   spec.add_dependency 'html-pipeline', '>= 2.14.3', '~> 2.14'
   spec.add_dependency 'sass-embedded', '~> 1.58'
+  spec.add_dependency 'ostruct', '~> 0.6'
+  spec.add_dependency 'logger', '~> 1.6'
 
   spec.add_development_dependency 'html-proofer', '~> 3.4'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -32,7 +32,7 @@ class CliTest < Minitest::Test
       assert cmd("--help")
     end
     assert_match /Usage/, out
-    assert err.empty?
+    assert err.empty?, "errors not empty"
   end
 
   def test_cli_verbose
@@ -41,14 +41,14 @@ class CliTest < Minitest::Test
     end
     assert_match /Generating site/, out
     assert_match /Site successfully generated/, out
-    assert err.empty?
+    assert err.empty?, "errors not empty"
   end
 
   def test_cli_base_url
     out, err = capture_subprocess_io do
       assert cmd("#{@schema} -b https://example.com")
     end
-    assert err.empty?
+    assert err.empty?, "errors not empty"
     assert File.read(File.join("output", 'index.html')).include?("<link rel=\"stylesheet\" href=\"https://example.com/assets/style.css\">")
   end
 
@@ -57,7 +57,7 @@ class CliTest < Minitest::Test
       assert cmd("--version")
     end
     assert_match /#{GraphQLDocs::VERSION}/, out
-    assert err.empty?
+    assert err.empty?, "errors not empty"
   end
 
   private


### PR DESCRIPTION
they're no longer going to be in the ruby std lib in future versions so
this adds them explicitly

this should get CI green again