### PR TITLE
Address deprecation warnings with mutex_m and Sass @import

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.3, 3.2, 3.1]
+        ruby-version: [3.4.0-preview2, 3.3, 3.2, 3.1]
 
     steps:
       - uses: actions/checkout@v2

--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'logger', '~> 1.6'
 
   spec.add_development_dependency 'html-proofer', '~> 3.4'
-  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'minitest', '~> 5.24'
   spec.add_development_dependency 'minitest-focus', '~> 1.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rubocop', '~> 1.37'

--- a/lib/graphql-docs/layouts/assets/css/screen.scss
+++ b/lib/graphql-docs/layouts/assets/css/screen.scss
@@ -1,7 +1,8 @@
 @charset "utf-8";
 
-@import "../_sass/_normalize.scss";
-@import "../_sass/_fonts";
+@use "sass:meta";
+@use "../_sass/_normalize.scss";
+@use "../_sass/_fonts";
 
 body {
   font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -39,11 +40,11 @@ em {
   font-family: 'ProximaNova-Semibold';
 }
 
-@import '../_sass/_header';
-@import '../_sass/_sidebar';
-@import '../_sass/_content';
-@import '../_sass/_types';
-@import '../_sass/_mobile';
-@import '../_sass/_api-box';
-@import '../_sass/_syntax';
-@import '../_sass/_deprecations';
+@include meta.load-css('../_sass/_header');
+@include meta.load-css('../_sass/_sidebar');
+@include meta.load-css('../_sass/_content');
+@include meta.load-css('../_sass/_types');
+@include meta.load-css('../_sass/_mobile');
+@include meta.load-css('../_sass/_api-box');
+@include meta.load-css('../_sass/_syntax');
+@include meta.load-css('../_sass/_deprecations');

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -32,7 +32,7 @@ class CliTest < Minitest::Test
       assert cmd("--help")
     end
     assert_match /Usage/, out
-    assert err.empty?, "errors not empty"
+    assert err.empty?, "errors not empty: #{err}"
   end
 
   def test_cli_verbose
@@ -41,14 +41,14 @@ class CliTest < Minitest::Test
     end
     assert_match /Generating site/, out
     assert_match /Site successfully generated/, out
-    assert err.empty?, "errors not empty"
+    assert err.empty?, "errors not empty: #{err}"
   end
 
   def test_cli_base_url
     out, err = capture_subprocess_io do
       assert cmd("#{@schema} -b https://example.com")
     end
-    assert err.empty?, "errors not empty"
+    assert err.empty?, "errors not empty: #{err}"
     assert File.read(File.join("output", 'index.html')).include?("<link rel=\"stylesheet\" href=\"https://example.com/assets/style.css\">")
   end
 
@@ -57,7 +57,7 @@ class CliTest < Minitest::Test
       assert cmd("--version")
     end
     assert_match /#{GraphQLDocs::VERSION}/, out
-    assert err.empty?, "errors not empty"
+    assert err.empty?, "errors not empty: #{err}"
   end
 
   private


### PR DESCRIPTION
- **Output CLI errors in test assertions**
- **Pin minitest to latest minor ver** - fixes https://github.com/brettchalupa/graphql-docs/issues/157
- **Fix Sass `@import` deprecation** - fixes https://github.com/brettchalupa/graphql-docs/issues/158
