### PR TITLE
Update Ruby 3.4 build to not use preview

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.4.0-preview2, 3.3, 3.2, 3.1]
+        ruby-version: [3.4, 3.3, 3.2, 3.1]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Now that it's released